### PR TITLE
Add packages required by the `elastic/logs` Rally track

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,17 @@
 tracked-packages:
+  - apache:
+      minimum-version: 1.3.0
   - endpoint:
       minimum-version: 8
+  - kafka:
+      minimum-version: 0.5.0
+  - mysql:
+      minimum-version: 1.1.0
+  - nginx:
+      minimum-version: 1.2.0
+  - postgresql:
+      minimum-version: 1.2.0
+  - redis:
+      minimum-version: 1.1.0
+  - system:
+      minimum-version: 1.6.4


### PR DESCRIPTION
This PR adds the packages necessary to implement https://github.com/elastic/rally-tracks/issues/305. I've set their minimum versions to the package versions currently used by the `elastic/logs` track, introduced in https://github.com/elastic/rally-tracks/pull/279.

I tested this locally using the `bot plan` and `bot update` commands. Things worked as expected and I was able to mimic the CI workflow on my machine.

Strictly speaking, we only need the `production` assets right now, so I'm happy to limit it to that branch if you'd prefer.